### PR TITLE
nodejs 16.13.1

### DIFF
--- a/recipe/0001-Force-include-handler-outside-simulator.patch
+++ b/recipe/0001-Force-include-handler-outside-simulator.patch
@@ -1,0 +1,44 @@
+From 5cc88ca0dfdeaa55a2862d1c86a1a291f7b440c9 Mon Sep 17 00:00:00 2001
+From: "Uwe L. Korn" <uwe.korn@quantco.com>
+Date: Mon, 25 Oct 2021 11:15:41 +0200
+Subject: [PATCH] Force-include handler-outside-simulator
+
+---
+ deps/v8/src/trap-handler/handler-outside-simulator.cc | 4 ++++
+ tools/v8_gypfiles/v8.gyp                              | 1 +
+ 2 files changed, 5 insertions(+)
+
+diff --git a/deps/v8/src/trap-handler/handler-outside-simulator.cc b/deps/v8/src/trap-handler/handler-outside-simulator.cc
+index cc1e20ee..db287144 100644
+--- a/deps/v8/src/trap-handler/handler-outside-simulator.cc
++++ b/deps/v8/src/trap-handler/handler-outside-simulator.cc
+@@ -2,6 +2,9 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
++#if (!defined(_M_X64) && !defined(__x86_64__)) || defined(V8_TARGET_ARCH_X64)
++#warning "Do only include this file on simulator builds on x64."
++#else
+ #include "include/v8config.h"
+ #include "src/trap-handler/trap-handler-simulator.h"
+ 
+@@ -31,3 +34,4 @@ asm(
+     SYMBOL(v8_probe_memory_continuation) ":         \n"
+     // If the trap handler continues here, it wrote the landing pad in %rax.
+     "  ret                                          \n");
++#endif
+diff --git a/tools/v8_gypfiles/v8.gyp b/tools/v8_gypfiles/v8.gyp
+index 0a39f771..f1e6471e 100644
+--- a/tools/v8_gypfiles/v8.gyp
++++ b/tools/v8_gypfiles/v8.gyp
+@@ -866,6 +866,7 @@
+               'sources': [
+                 "<(V8_ROOT)/src/trap-handler/handler-inside-posix.cc",
+                 "<(V8_ROOT)/src/trap-handler/handler-outside-posix.cc",
++                "<(V8_ROOT)/src/trap-handler/handler-outside-simulator.cc",
+               ],
+             }],
+             ['OS=="win"', {
+-- 
+2.30.1 (Apple Git-130)
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ source:
 
 build:
   number: 0
+  # Anaconda doesn't provide nodejs on s390x because it's not included in SOW packages
   skip: True  # [s390x]
   # Prefix replacement breaks in the binary embedded configurations.
   detect_binary_files_with_prefix: false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,9 +16,8 @@ source:
   patches:
     - linux-librt.patch  # [not win]
     - cinttypes.patch  # [linux]
-    - less-shared-intermediate.patch  # [build_platform != target_platform]
-    - 0001-Use-HOST-instead-of-TARGET-to-determine-thread-conte.patch  # [build_platform != target_platform]
     - 0001-Forward-ceilf-floorf.patch  # [not win]
+    - 0001-Force-include-handler-outside-simulator.patch  # [osx and arm64]
 
 build:
   number: 0
@@ -66,6 +65,7 @@ test:
 about:
   home: https://nodejs.org/
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: a platform for easily building fast, scalable network applications
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "16.6.1" %}
+{% set version = "16.13.1" %}
 
 # NODE_MODULE_VERSION set in src/node_version.h
 {% set NODE_MODULE_VERSION = 93 %}
@@ -10,9 +10,9 @@ package:
 source:
   fn: node-v{{ version }}.tar.gz
   url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}.tar.gz  # [not win]
-  sha256: 36467b8a4e7e3bacc2f4f1709a83b0506429d1999bc461e5e363bc91d3437c09  # [not win]
+  sha256: a9147e9a86f8420893bafc4ef041e578795dc5874b9dccdd731699613b8a60ab  # [not win]
   url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}-win-x64.zip  # [win]
-  sha256: ec5dce1e182172cc7edc8d56c377f4d106232b2b14127bd2a1565497448504e9  # [win]
+  sha256: a9147e9a86f8420893bafc4ef041e578795dc5874b9dccdd731699613b8a60ab  # [win]
   patches:
     - linux-librt.patch  # [not win]
     - cinttypes.patch  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [s390x]
   # Prefix replacement breaks in the binary embedded configurations.
   detect_binary_files_with_prefix: false
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ package:
 source:
   fn: node-v{{ version }}.tar.gz
   url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}.tar.gz  # [not win]
-  sha256: a9147e9a86f8420893bafc4ef041e578795dc5874b9dccdd731699613b8a60ab  # [not win]
+  sha256: 34b23965457fb08a8c62f81e8faf74ea60587cda6fa898e5d030211f5f374cb6  # [not win]
   url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}-win-x64.zip  # [win]
   sha256: a9147e9a86f8420893bafc4ef041e578795dc5874b9dccdd731699613b8a60ab  # [win]
   patches:
@@ -40,7 +40,7 @@ requirements:
     - vs2015_runtime  # [win]
     - icu >=65  # [not win]
     - libuv >=1.33  # [not win]
-    - openssl  >=1.1.1d  # [not win]
+    - openssl >=1.1.1d  # [not win]
     - zlib  # [not win]
   run:
     - vs2015_runtime  # [win]


### PR DESCRIPTION
Update nodejs to 16.13.1

Version change: bump version number from 16.6.1 to 16.13.1
Requirements from conda-forge: https://github.com/conda-forge/nodejs-feedstock/blob/master/recipe/meta.yaml
Building from sources: https://github.com/nodejs/node/blob/master/BUILDING.md

The package nodejs is mentioned inside the packages:
configurable-http-proxy | geoviews | h2o | jupyterlab | nbpresent | panel | ray-packages | yarn |

Actions:
1. Add (m2-)patch
2. Add license_family

Result:
- all-succeeded