### PR TITLE
Revert openssl pin back to 3.*

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - 0002-ppc64le-remove-const.patch  # [ppc64le]
 
 build:
-  number: 1
+  number: 2
   # Anaconda doesn't provide nodejs on s390x because it's not included in SOW packages
   skip: True  # [s390x]
   # Prefix replacement breaks in the binary embedded configurations.
@@ -43,7 +43,7 @@ requirements:
   run:
     - {{ pin_compatible('icu') }}
     - libuv  # [not win]
-    - openssl # [not win]
+    - openssl 3.*  # [not win]
     - zlib  # [not win]
   run_constrained:   # [osx]
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}   # [osx and x86_64]


### PR DESCRIPTION
Due to a bad rebase the openssl pin to 3.* got lost, and we built for both 1.* and 3.*. this commit reverts this