### PR TITLE
nodejs 18.18.2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,12 +7,6 @@ macos_min_version:  # [osx]
 CONDA_BUILD_SYSROOT:            # [osx and x86_64]
   - /opt/MacOSX10.14.sdk        # [osx and x86_64]
 
-# Use gcc 8 for ppc64le
-c_compiler_version:            # [ppc64le]
-  - 8                          # [ppc64le]
-cxx_compiler_version:          # [ppc64le]
-  - 8                          # [ppc64le]
-
 pin_run_as_build:
   # libuv is missing run_exports
   libuv:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "18.18.2" %}
+{% set version = "18.19.0" %}
 
 # NODE_MODULE_VERSION set in src/node_version.h
 {% set NODE_MODULE_VERSION = 108 %}
@@ -10,9 +10,9 @@ package:
 source:
   # checksums from https://nodejs.org/dist/vX.Y.Z/SHASUMS256.txt.asc
   url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}.tar.gz  # [unix]
-  sha256: 509cd2cfc3a515bf2257ed3886b9fac64aeaac2a70ea59c0a6e02e2dbb722132  # [unix]
+  sha256: dd4c1dc1cb94e1e29f65a3a592247edeb8ceb23483123b0e1847d75c5f0b0c17  # [unix]
   url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}-win-x64.zip  # [win]
-  sha256: 3bb0e51e579a41a22b3bf6cb2f3e79c03801aa17acbe0ca00fc555d1282e7acd  # [win]
+  sha256: 5311913d45e1fcc3643c58d1e3926eb85437b180f025fe5857413c9f02403645  # [win]
   patches:  # [not win]
     - linux-librt.patch  # [not win]
     - cinttypes.patch  # [linux]
@@ -20,7 +20,7 @@ source:
     - 0001-Forward-ceilf-floorf.patch  # [not win]
 
 build:
-  number: 1
+  number: 0
   # Anaconda doesn't provide nodejs on s390x because it's not included in SOW packages
   skip: True  # [s390x]
   # Prefix replacement breaks in the binary embedded configurations.
@@ -36,7 +36,7 @@ requirements:
     - patch     # [not win]
   host:
     - libuv 1.44    # [not win]
-    - openssl {{ openssl }} # [not win]
+    - openssl # [not win]
     - zlib 1.2      # [not win]
     - icu 73
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - patch     # [not win]
   host:
     - libuv 1.44    # [not win]
-    - openssl # [not win]
+    - openssl {{ openssl }} # [not win]
     - zlib 1.2      # [not win]
     - icu 73
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "18.16.0" %}
+{% set version = "18.18.2" %}
 
 # NODE_MODULE_VERSION set in src/node_version.h
 {% set NODE_MODULE_VERSION = 108 %}
@@ -10,15 +10,14 @@ package:
 source:
   # checksums from https://nodejs.org/dist/vX.Y.Z/SHASUMS256.txt.asc
   url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}.tar.gz  # [unix]
-  sha256: 6a4f5c5d76e5c50cef673099e56f19bc3266ae363f56ca0ab77dd2f3c5088c6d  # [unix]
+  sha256: 509cd2cfc3a515bf2257ed3886b9fac64aeaac2a70ea59c0a6e02e2dbb722132  # [unix]
   url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}-win-x64.zip  # [win]
-  sha256: 4b3bd4cb5570cc217490639e93a7e1b7a7a341981366661e514ce61941824a85  # [win]
+  sha256: 3bb0e51e579a41a22b3bf6cb2f3e79c03801aa17acbe0ca00fc555d1282e7acd  # [win]
   patches:  # [not win]
     - linux-librt.patch  # [not win]
     - cinttypes.patch  # [linux]
     - less-shared-intermediate.patch  # [not win]
     - 0001-Forward-ceilf-floorf.patch  # [not win]
-    - 0002-ppc64le-remove-const.patch  # [ppc64le]
 
 build:
   number: 1
@@ -32,7 +31,7 @@ requirements:
     - {{ compiler('c') }}  # [not win]
     - {{ compiler('cxx') }}  # [not win]
     - python 3.8  # [not win]
-    - ninja  # [not win]
+    - ninja-base  # [not win]
     - pkg-config  # [not win]
     - patch     # [not win]
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "18.19.0" %}
+{% set version = "18.18.2" %}
 
 # NODE_MODULE_VERSION set in src/node_version.h
 {% set NODE_MODULE_VERSION = 108 %}
@@ -10,9 +10,9 @@ package:
 source:
   # checksums from https://nodejs.org/dist/vX.Y.Z/SHASUMS256.txt.asc
   url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}.tar.gz  # [unix]
-  sha256: dd4c1dc1cb94e1e29f65a3a592247edeb8ceb23483123b0e1847d75c5f0b0c17  # [unix]
+  sha256: 509cd2cfc3a515bf2257ed3886b9fac64aeaac2a70ea59c0a6e02e2dbb722132  # [unix]
   url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}-win-x64.zip  # [win]
-  sha256: 5311913d45e1fcc3643c58d1e3926eb85437b180f025fe5857413c9f02403645  # [win]
+  sha256: 3bb0e51e579a41a22b3bf6cb2f3e79c03801aa17acbe0ca00fc555d1282e7acd  # [win]
   patches:  # [not win]
     - linux-librt.patch  # [not win]
     - cinttypes.patch  # [linux]


### PR DESCRIPTION
nodejs 18.18.2

**Destination channel:** main

### Links

- [PKG-3225](https://anaconda.atlassian.net/browse/PKG-3225) 
- [Upstream repository](https://github.com/nodejs/node/tree/v18.18.2)
- [Changelog](https://github.com/nodejs/node/blob/v18.18.2/doc/changelogs/CHANGELOG_V18.md#18.18.2)

### Explanation of changes:

- Reset the build number
- Remove `0002-ppc64le-remove-const.patch` as we do not support `linux-ppc64le `anymore
- Replace `ninja` by `ninja-base` 

### Notes:
- to address CVE-2023-44487 (HTTP/2 Rapid Reset) with a score of 7.5

[PKG-3225]: https://anaconda.atlassian.net/browse/PKG-3225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ