### PR TITLE
nodejs 20.9.0

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -54,7 +54,7 @@ fi
 if [[ "${target_platform}" != osx-* ]]; then
   cp out/Release/lib/libnode.* out/Release/
 fi
-$PYTHON tools/install.py install ${PREFIX} ''
+$PYTHON tools/install.py install --dest-dir ${PREFIX} --prefix
 cp out/Release/node $PREFIX/bin
 
 node -v

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -58,7 +58,7 @@ fi
 if [[ "${target_platform}" != osx-* ]]; then
   cp out/Release/lib/libnode.* out/Release/
 fi
-$PYTHON tools/install.py install --dest-dir ${PREFIX} --prefix
+$PYTHON tools/install.py install --dest-dir ${PREFIX} --prefix ''
 cp out/Release/node $PREFIX/bin
 
 node -v

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,6 +12,10 @@ else
     # need librt for clock_gettime with nodejs >= 12.12
     export LDFLAGS="$LDFLAGS -lrt"
     echo "LDFLAGS=$LDFLAGS"
+
+    # https://github.com/nodejs/node/issues/52223
+    sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' deps/cares/config/linux/ares_config.h
+    sed -i 's/define HAVE_GETRANDOM 1/undef HAVE_GETRANDOM/g' deps/cares/config/linux/ares_config.h
 fi
 
 EXTRA_ARGS=

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -48,7 +48,7 @@ if [ "$(uname -m)" = "ppc64le" ]; then
     CPU_COUNT=$((CPU_COUNT / 4))
     ninja -C out/Release -j${CPU_COUNT}
 else
-    ninja -C out/Release
+    ninja -C out/Release -j${CPU_COUNT}
 fi
 
 if [[ "${target_platform}" != osx-* ]]; then

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,10 +1,3 @@
-MACOSX_DEPLOYMENT_TARGET:  # [osx]
-  - '10.15'  # [osx and x86_64]
-macos_min_version:  # [osx]
-  - '10.15'  # [osx and x86_64]
-CONDA_BUILD_SYSROOT:            # [osx and x86_64]
-  - /opt/MacOSX10.15.sdk        # [osx and x86_64]
-
 pin_run_as_build:
   # libuv is missing run_exports
   libuv:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,11 +1,9 @@
 MACOSX_DEPLOYMENT_TARGET:  # [osx]
-  - '10.14'  # [osx and x86_64]
-  - '10.15'  # [osx and arm64]
+  - '10.15'  # [osx and x86_64]
 macos_min_version:  # [osx]
-  - '10.14'  # [osx and x86_64]
-  - '10.15'  # [osx and arm64]
+  - '10.15'  # [osx and x86_64]
 CONDA_BUILD_SYSROOT:            # [osx and x86_64]
-  - /opt/MacOSX10.14.sdk        # [osx and x86_64]
+  - /opt/MacOSX10.15.sdk        # [osx and x86_64]
 
 pin_run_as_build:
   # libuv is missing run_exports

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,12 @@ requirements:
     - libuv
   host:
     - icu {{ icu }}
-    - libuv 1.44             # [not win]
+    # The introduction of the uv_pipe_bind2 and uv_pipe_connect2 methods in
+    # libuv v1.46.0 changed the behaviour of uv_pipe_bind and uv_pipe_connect.
+    # see https://github.com/nodejs/node/pull/49667 and https://docs.libuv.org/en/v1.x/pipe.html#c.uv_pipe_bind2
+    # uv_pipe_bind2 added in v20.8.0 of the 20.x branch
+    # https://github.com/nodejs/node/blob/v20.8.0/src/pipe_wrap.cc
+    - libuv 1.48             # [not win]
     - openssl {{ openssl }}  # [not win]
     - zlib {{ zlib }}        # [not win]
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
-{% set version = "18.18.2" %}
+{% set version = "20.9.0" %}
 
 # NODE_MODULE_VERSION set in src/node_version.h
-{% set NODE_MODULE_VERSION = 108 %}
+{% set NODE_MODULE_VERSION = 115 %}
 
 package:
   name: nodejs
@@ -10,9 +10,9 @@ package:
 source:
   # checksums from https://nodejs.org/dist/vX.Y.Z/SHASUMS256.txt.asc
   url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}.tar.gz  # [unix]
-  sha256: 509cd2cfc3a515bf2257ed3886b9fac64aeaac2a70ea59c0a6e02e2dbb722132  # [unix]
+  sha256: a7e6547a951406e4e546a74160ed27b26f9abd4baf7c44dd5a0fa992852d0cfa  # [unix]
   url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}-win-x64.zip  # [win]
-  sha256: 3bb0e51e579a41a22b3bf6cb2f3e79c03801aa17acbe0ca00fc555d1282e7acd  # [win]
+  sha256: 70d87dad2378c63216ff83d5a754c61d2886fc39d32ce0d2ea6de763a22d3780  # [win]
   patches:  # [not win]
     - linux-librt.patch  # [not win]
     - cinttypes.patch  # [linux]
@@ -28,22 +28,22 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}  # [not win]
+    - {{ compiler('c') }}    # [not win]
     - {{ compiler('cxx') }}  # [not win]
-    - python 3.8  # [not win]
-    - ninja-base  # [not win]
-    - pkg-config  # [not win]
-    - patch     # [not win]
+    - python 3.8             # [not win]
+    - ninja-base             # [not win]
+    - pkg-config             # [not win]
+    - patch                  # [not win]
   host:
-    - libuv 1.44    # [not win]
-    - openssl {{ openssl }} # [not win]
-    - zlib 1.2      # [not win]
-    - icu 73
+    - icu {{ icu }}
+    - libuv 1.44             # [not win]
+    - openssl {{ openssl }}  # [not win]
+    - zlib {{ zlib }}        # [not win]
   run:
     - {{ pin_compatible('icu') }}
-    - libuv  # [not win]
-    - openssl # [not win]
-    - zlib  # [not win]
+    - libuv                  # [not win]
+    - openssl                # [not win]
+    - zlib                   # [not win]
   run_constrained:   # [osx]
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}   # [osx and x86_64]
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.15") }}  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,9 @@ requirements:
     - ninja-base             # [not win]
     - pkg-config             # [not win]
     - patch                  # [not win]
+    # libuv is a bootstrap dependency in js2c
+    # starting with 20.3 (https://github.com/nodejs/node/pull/46997)
+    - libuv
   host:
     - icu {{ icu }}
     - libuv 1.44             # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "20.9.0" %}
+{% set version = "20.17.0" %}
 
 # NODE_MODULE_VERSION set in src/node_version.h
 {% set NODE_MODULE_VERSION = 115 %}
@@ -10,9 +10,9 @@ package:
 source:
   # checksums from https://nodejs.org/dist/vX.Y.Z/SHASUMS256.txt.asc
   url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}.tar.gz  # [unix]
-  sha256: a7e6547a951406e4e546a74160ed27b26f9abd4baf7c44dd5a0fa992852d0cfa  # [unix]
+  sha256: 409bda5f1896c7c20866610d778d1760991884ad2e7940837cd3f2854cf73747  # [unix]
   url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}-win-x64.zip  # [win]
-  sha256: 70d87dad2378c63216ff83d5a754c61d2886fc39d32ce0d2ea6de763a22d3780  # [win]
+  sha256: e323fff0aba197090faabd29c4c23f334557ff24454324f0c83faa7e399dbb74  # [win]
   patches:  # [not win]
     - linux-librt.patch  # [not win]
     - cinttypes.patch  # [linux]
@@ -36,7 +36,7 @@ requirements:
     - patch                  # [not win]
     # libuv is a bootstrap dependency in js2c
     # starting with 20.3 (https://github.com/nodejs/node/pull/46997)
-    - libuv
+    - libuv 1.48
   host:
     - icu {{ icu }}
     # The introduction of the uv_pipe_bind2 and uv_pipe_connect2 methods in
@@ -53,8 +53,8 @@ requirements:
     - openssl                # [not win]
     - zlib                   # [not win]
   run_constrained:   # [osx]
-    - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}   # [osx and x86_64]
-    - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.15") }}  # [osx and arm64]
+    - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.15") }}   # [osx and x86_64]
+    - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("11.1") }}  # [osx and arm64]
 
 test:
   commands:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5659](https://anaconda.atlassian.net/browse/PKG-5659) 
- [Upstream repository](https://github.com/nodejs/node/tree/v20.9.0)
- [Changelog](https://github.com/nodejs/node/blob/v20.9.0/doc/changelogs/CHANGELOG_V20.md#20.9.0)

### Explanation of changes:

- Use `-j${CPU_COUNT}` on Unix platforms
- Add `libuv` to build as it's a bootstrap dependency in js2c starting with 20.3, see https://github.com/nodejs/node/pull/46997
- Use `libuv 1.48` in `host` because of new `uv_pipe_bind2` and `uv_pipe_connect2` methods 

### Notes:

- jupyterlab 4.2.5 requires nodejs >=20,<21 at runtime

[PKG-5659]: https://anaconda.atlassian.net/browse/PKG-5659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ